### PR TITLE
Add some warnings and errors for cohort methods.

### DIFF
--- a/R/cohort_methods.R
+++ b/R/cohort_methods.R
@@ -227,7 +227,7 @@ Cohort <- R6::R6Class(
       }
       if (!missing(active)) {
         if(!is.logical(active)) {
-          warning("Active accepts only logical values")
+          warning("Active accepts only logical values.")
         } else {
           filter_env[["active"]] <- active
         }

--- a/R/cohort_methods.R
+++ b/R/cohort_methods.R
@@ -225,9 +225,12 @@ Cohort <- R6::R6Class(
           filter_env[[param_name]] <- new_val
         }
       }
-
       if (!missing(active)) {
-        filter_env[["active"]] <- active
+        if(!is.logical(active)) {
+          warning("Active accepts only logical values")
+        } else {
+          filter_env[["active"]] <- active
+        }
       }
 
       if (run_flow && (!missing(active) || any_changed)) {

--- a/R/cohort_methods.R
+++ b/R/cohort_methods.R
@@ -459,6 +459,11 @@ Cohort <- R6::R6Class(
       if (state == "pre") {
         data_id <- prev_step(step_id)
       }
+
+      if(is.null(self$get_step(step_id)) && step_id != 0){
+        stop("Step is not exist in this cohort object.")
+      }
+
       if (missing(filter_id)) {
         return(
           .get_stats(private$source, private$data_objects[[data_id]])

--- a/tests/testthat/test-cohort_methods.R
+++ b/tests/testthat/test-cohort_methods.R
@@ -492,6 +492,11 @@ test_that("Updating filter works fine", {
     label = "Cannot modify filter ‘type’, ‘id’, ‘name’ parameters."
   )
 
+  expect_warning(
+    coh$update_filter(1L, "sepal_l", active = "FALSE"),
+    regexp = "Active accepts only logical values."
+  )
+
   # Using S3 Cohort methods
   coh <- cohort(
     set_source(
@@ -514,6 +519,11 @@ test_that("Updating filter works fine", {
   expect_warning(
     coh$update_filter(1L, "sepal_l", type = "discrete"),
     label = "Cannot modify filter ‘type’, ‘id’, ‘name’ parameters."
+  )
+
+  expect_warning(
+    coh$update_filter(1L, "sepal_l", active = "FALSE"),
+    regexp = "Active accepts only logical values."
   )
 })
 

--- a/tests/testthat/test-cohort_methods.R
+++ b/tests/testthat/test-cohort_methods.R
@@ -642,6 +642,11 @@ test_that("Getting filter stats works fine", {
     as.list(table(iris$Species[iris$Species %in% c("setosa", "virginica")]))
   )
 
+  expect_error(
+    stat(coh,10),
+    regexp = "Step is not exist in this cohort object."
+  )
+
   # Using S3 Cohort methods
   coh <- cohort(
     set_source(


### PR DESCRIPTION
Add warning for 'update_filter' and 'stat' function for #15 
### update_filter
### Before:

```
> coh$update_filter(1L, "film_filter", active = "FALSE")

> get_state(coh)
[[1]]
[[1]]$step
[1] "1"
...
[[1]]$filters[[2]]$active
[1] "FALSE"

> run(coh)
Error in `purrr::keep()`:
ℹ In index: 2.
ℹ With name: film_filter.
Caused by error:
! `.p()` must return a single `TRUE` or `FALSE`, not a string.
Run `rlang::last_trace()` to see where the error occurred.
```

### After:

```
> coh$update_filter(1L, "film_filter", active = "FALSE")
Warning message:
In coh$update_filter(1L, "film_filter", active = "FALSE") :
  Active accepts only logical values

> get_state(coh)
[[1]]
[[1]]$step
[1] "1"
...
[[1]]$filters[[2]]$active
[1] TRUE

> run(coh)
```
```
> coh$update_filter(1L, "film_filter", active = FALSE)
> get_state(coh)
[[1]]
[[1]]$step
[1] "1"
...
[[1]]$filters[[2]]$active
[1] FALSE
```
### stat
### Before:
```
> stat(coh,10)
$actor
$actor$n_rows
NULL

...

$store
$store$n_rows
NULL
```
### After:
```
> stat(coh,10)
Error in x$get_stats(step_id, filter_id, ..., state = state) : 
  Step is not exist in this cohort object.
```


